### PR TITLE
set free parking spots to zero if reported number of cars is too high

### DIFF
--- a/src/main/java/de/starwit/odp/ODPFunctions.java
+++ b/src/main/java/de/starwit/odp/ODPFunctions.java
@@ -130,7 +130,12 @@ public class ODPFunctions {
             checkIfTokenIsStillValid();
             if(token != null) {
                 if(ofs.isSynched()) {
-                    ofs.setAvailableParkingSpots(ofs.getTotalSpotNumber() - repository.getParkedCars());
+                    if(ofs.getTotalSpotNumber() - repository.getParkedCars() < 0) {
+                        ofs.setAvailableParkingSpots(ofs.getTotalSpotNumber() - repository.getParkedCars());
+                    } else {
+                        ofs.setAvailableParkingSpots(0);
+                    }
+                    
                     sendOnStreetParkingUpdate(ofs);
                 }
             } else {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -39,6 +39,6 @@ logging.level.de.starwit=INFO
 # Configure mapping to parking area
 odp.parkingareaid=OnStreetParking:38444039
 # fallback default, if reading value from ODP fails
-odp.parkingareaid.defaulttotal=70
+odp.parkingareaid.defaulttotal=64
 # prefix for observation areas to sum
 analytics.observation_area_prefix=parking


### PR DESCRIPTION
If number of parked vehicles is too large, negative values for available parking spots could appear. 

## Description
Available spots are set to 0, if too many vehicles are detected.


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
